### PR TITLE
Correct repository URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/lucthev/array-diff"
+    "url": "https://github.com/lucthev/generic-diff"
   },
   "keywords": [
     "array",
@@ -19,9 +19,9 @@
   "author": "Luc Thevenard <lucthevenard@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/lucthev/array-diff/issues"
+    "url": "https://github.com/lucthev/generic-diff/issues"
   },
-  "homepage": "https://github.com/lucthev/array-diff",
+  "homepage": "https://github.com/lucthev/generic-diff",
   "devDependencies": {
     "tape": "^3.5.0"
   },


### PR DESCRIPTION
Thanks so much for this package!

I noticed that the URLs in package.json don't match the name of your repository on GitHub. That breaks the link from https://www.npmjs.com/package/generic-diff, among other things. Thought you might like to correct with a patch release.
